### PR TITLE
Create central app as part of e2e script

### DIFF
--- a/vsts_ci/azure-pipelines-e2e.yml
+++ b/vsts_ci/azure-pipelines-e2e.yml
@@ -16,6 +16,11 @@ stages:
         sudo apt update
         sudo apt install jq
       displayName: 'Install jq'
+    - task: AzureKeyVault@1
+      inputs:
+        azureSubscription: 'Azure IoT DDE team subscription(377c3343-75bb-4244-98a3-0fb84a830c4b)'
+        KeyVaultName: 'azure-iot-edgetools-kv'
+        SecretsFilter: 'ddeiotedgetestpw'
     - task: AzureCLI@2
       inputs:
         azureSubscription: 'Connection to Pipeline resources for IoT Edge Config'
@@ -25,9 +30,10 @@ stages:
           az upgrade
           az extension add --name azure-iot
           az --version
+          az login -u "ddeiotedgetest@microsoft.com" -p "$(ddeiotedgetestpw)"
           az account set -s $(AzureSubscriptionId)
       displayName: 'Set Azure resources'
-        
+    
   - job: LinuxE2ETests
     pool:
       vmImage: ubuntu-18.04

--- a/vsts_ci/azure-pipelines-e2e.yml
+++ b/vsts_ci/azure-pipelines-e2e.yml
@@ -18,31 +18,6 @@ stages:
       displayName: 'Install jq'
     - task: AzureCLI@2
       inputs:
-        azureSubscription: 'Azure IoT DDE team subscription(377c3343-75bb-4244-98a3-0fb84a830c4b)'
-        scriptType: 'ps'
-        scriptLocation: 'inlineScript'
-        inlineScript: |
-          Write-Host "##vso[task.setvariable variable=SpId;]$env:servicePrincipalId"
-          Write-Host "##vso[task.setvariable variable=SpKey;]$env:servicePrincipalKey"
-          Write-Host "##vso[task.setvariable variable=TenantId;]$env:tenantId"
-          Write-Host "##vso[task.setvariable variable=TestVar;]JustForTest"
-    - task: PowerShell@2
-      inputs:
-        targetType: 'inline'
-        script: |
-          # Write your PowerShell commands here.
-          Write-Host "Hello World"
-          Write-Host $env:SpId
-          Write-Host $env:SpKey
-          Write-Host $env:TenantId
-          Write-Host $env:TestVar
-#    - task: AzureKeyVault@1
-#      inputs:
-#        azureSubscription: 'Azure IoT DDE team subscription(377c3343-75bb-4244-98a3-0fb84a830c4b)'
-#        KeyVaultName: 'azure-iot-edgetools-kv'
-#        SecretsFilter: 'ddeiotedgetestpw'
-    - task: AzureCLI@2
-      inputs:
         azureSubscription: 'Connection to Pipeline resources for IoT Edge Config'
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
@@ -50,7 +25,6 @@ stages:
           az upgrade
           az extension add --name azure-iot
           az --version
-          az login -u "ddeiotedgetest@microsoft.com" -p "$(ddeiotedgetestpw)"
           az account set -s $(AzureSubscriptionId)
       displayName: 'Set Azure resources'
     

--- a/vsts_ci/azure-pipelines-e2e.yml
+++ b/vsts_ci/azure-pipelines-e2e.yml
@@ -16,11 +16,31 @@ stages:
         sudo apt update
         sudo apt install jq
       displayName: 'Install jq'
-    - task: AzureKeyVault@1
+    - task: AzureCLI@2
       inputs:
         azureSubscription: 'Azure IoT DDE team subscription(377c3343-75bb-4244-98a3-0fb84a830c4b)'
-        KeyVaultName: 'azure-iot-edgetools-kv'
-        SecretsFilter: 'ddeiotedgetestpw'
+        scriptType: 'ps'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          Write-Host "##vso[task.setvariable variable=SpId;]$env:servicePrincipalId"
+          Write-Host "##vso[task.setvariable variable=SpKey;]$env:servicePrincipalKey"
+          Write-Host "##vso[task.setvariable variable=TenantId;]$env:tenantId"
+          Write-Host "##vso[task.setvariable variable=TestVar;]JustForTest"
+    - task: PowerShell@2
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Write your PowerShell commands here.
+          Write-Host "Hello World"
+          Write-Host $env:SpId
+          Write-Host $env:SpKey
+          Write-Host $env:TenantId
+          Write-Host $env:TestVar
+#    - task: AzureKeyVault@1
+#      inputs:
+#        azureSubscription: 'Azure IoT DDE team subscription(377c3343-75bb-4244-98a3-0fb84a830c4b)'
+#        KeyVaultName: 'azure-iot-edgetools-kv'
+#        SecretsFilter: 'ddeiotedgetestpw'
     - task: AzureCLI@2
       inputs:
         azureSubscription: 'Connection to Pipeline resources for IoT Edge Config'


### PR DESCRIPTION
In order to allow the pipeline to retrieve the Central app API token, we are now creating the central app as part of the e2e test. This way the identity between the app creator and the device creator matches.